### PR TITLE
Make improvements for mobile

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,7 +2,13 @@ import streamlit as st
 from policyengine_core.charts import *
 from household_impact import display_household_impact
 from societal_impact import display_societal_impact
+from streamlit_js_eval import streamlit_js_eval
 
+
+# Measure viewport width using JS; this will evaluate to None before paint,
+# then to the actual value, so must test if value is None before using
+MOBILE_WIDTH_PX = 768
+viewport_width = streamlit_js_eval(js_expressions="window.outerWidth", key = "WOW")
 
 # Streamlit code for displaying the data
 st.title("UK 2024 Election Manifestos")
@@ -24,7 +30,7 @@ include_indirect_impacts = st.checkbox(
 tab1, tab2 = st.tabs(["Societal Impacts", "Household Impacts"])
 
 with tab1:
-    display_societal_impact(year, include_indirect_impacts)
+    display_societal_impact(year, include_indirect_impacts, viewport_width)
 
 with tab2:
-    display_household_impact(year, include_indirect_impacts)
+    display_household_impact(year, include_indirect_impacts, viewport_width)

--- a/household_impact.py
+++ b/household_impact.py
@@ -245,7 +245,11 @@ def fmt(value):
     return f"+£{value:,.0f}" if value >= 0 else f"-£{abs(value):,.0f}"
 
 
-def create_main_chart(df):
+def create_main_chart(df, viewport_width):
+    # Measure viewport width using JS; this will evaluate to None before paint,
+    # then to the actual value, so must test if value is None before using
+    MOBILE_WIDTH_PX = 768
+
     df["Text"] = df["Value"].apply(fmt)
     fig = px.bar(
         df,
@@ -290,7 +294,7 @@ def create_main_chart(df):
     return fig
 
 
-def display_household_impact(year, include_indirect_impacts):
+def display_household_impact(year, include_indirect_impacts, viewport_width):
     st.subheader("Household impact")
 
     situation = create_situation(year)
@@ -326,4 +330,4 @@ def display_household_impact(year, include_indirect_impacts):
         with st.expander("See breakdown"):
             st.dataframe(df, use_container_width=True)
 
-        st.plotly_chart(create_main_chart(df), use_container_width=True)
+        st.plotly_chart(create_main_chart(df, viewport_width), use_container_width=True)

--- a/household_impact.py
+++ b/household_impact.py
@@ -6,6 +6,7 @@ from reforms import *
 import plotly.express as px
 from policyengine_core.charts import *
 from policyengine_uk import Simulation
+from streamlit_js_eval import streamlit_js_eval
 
 
 # Define colors for the parties
@@ -250,6 +251,19 @@ def create_main_chart(df, viewport_width):
     # then to the actual value, so must test if value is None before using
     MOBILE_WIDTH_PX = 768
 
+    if viewport_width is not None and viewport_width < MOBILE_WIDTH_PX:
+        plotly_x = 0
+        plotly_y = -0.2
+        plotly_yanchor = "top"
+        plotly_xanchor = "left"
+        plotly_orientation = "h"
+    else:
+        plotly_x = 1
+        plotly_y = 1
+        plotly_yanchor = "middle"
+        plotly_xanchor = "left"
+        plotly_orientation = "v"
+
     df["Text"] = df["Value"].apply(fmt)
     fig = px.bar(
         df,
@@ -269,6 +283,17 @@ def create_main_chart(df, viewport_width):
     fig.update_traces(
         visible="legendonly",
         selector=dict(name="Net change excluding in-kind spending"),
+    )
+
+    # Format for viewport
+    fig.update_layout(
+        legend={
+          "x": plotly_x,
+          "y": plotly_y,
+          "xanchor": plotly_xanchor,
+          "yanchor": plotly_yanchor,
+          "orientation": plotly_orientation
+        }
     )
 
     winning_party = (

--- a/household_impact.py
+++ b/household_impact.py
@@ -253,17 +253,21 @@ def create_main_chart(df, viewport_width):
     MOBILE_WIDTH_PX = 768
 
     if viewport_width is not None and viewport_width < MOBILE_WIDTH_PX:
-        plotly_x = 0
-        plotly_y = -0.2
-        plotly_yanchor = "top"
-        plotly_xanchor = "left"
-        plotly_orientation = "h"
+        x = 0
+        y = -0.2
+        yanchor = "top"
+        xanchor = "left"
+        orientation = "h"
+        margin_r = 50
+        anim_frame_y = -0.3
     else:
-        plotly_x = 1
-        plotly_y = 1
-        plotly_yanchor = "middle"
-        plotly_xanchor = "left"
-        plotly_orientation = "v"
+        x = 1
+        y = 1
+        yanchor = "middle"
+        xanchor = "left"
+        orientation = "v"
+        margin_r = 0
+        anim_frame_y = 0
 
     df["Text"] = df["Value"].apply(fmt)
     fig = px.bar(
@@ -289,12 +293,21 @@ def create_main_chart(df, viewport_width):
     # Format for viewport
     fig.update_layout(
         legend={
-          "x": plotly_x,
-          "y": plotly_y,
-          "xanchor": plotly_xanchor,
-          "yanchor": plotly_yanchor,
-          "orientation": plotly_orientation
-        }
+          "x": x,
+          "y": y,
+          "xanchor": xanchor,
+          "yanchor": yanchor,
+          "orientation": orientation,
+        },
+        margin={
+            "r": margin_r
+        },
+        updatemenus=[{
+            "y": anim_frame_y
+        }],
+        sliders=[{
+            "y": anim_frame_y
+        }]
     )
 
     winning_party = (

--- a/household_impact.py
+++ b/household_impact.py
@@ -7,6 +7,7 @@ import plotly.express as px
 from policyengine_core.charts import *
 from policyengine_uk import Simulation
 from streamlit_js_eval import streamlit_js_eval
+import textwrap
 
 
 # Define colors for the parties
@@ -309,9 +310,17 @@ def create_main_chart(df, viewport_width):
 
     axis_range = max(df.Value.max(), -df.Value.min())
 
+    title = f'The <span style="color: {party_color}">{winning_party}</span> would increase your net income the most'
+
+    # Wrap title on mobile; this is hackish
+    ADJUSTMENT_FACTOR = 6
+    if viewport_width is not None and viewport_width < MOBILE_WIDTH_PX:
+        title_list = textwrap.wrap(title, viewport_width / ADJUSTMENT_FACTOR)
+        title = "<br>".join(title_list)
+
     fig = format_fig(fig).update_layout(
         showlegend=True,
-        title=f'The <span style="color: {party_color}">{winning_party}</span> would increase your net income the most',
+        title=title,
         yaxis_title="Net income change",
         yaxis_range=[-axis_range, axis_range],
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ streamlit
 policyengine_uk
 pandas
 plotly
+streamlit_js_eval

--- a/societal_impact.py
+++ b/societal_impact.py
@@ -2,6 +2,7 @@ import streamlit as st
 from policyengine_core.charts import *
 import pandas as pd
 import plotly.express as px
+from streamlit_js_eval import streamlit_js_eval
 
 LABOUR = "#E4003B"
 CONSERVATIVES = "#0087DC"
@@ -37,6 +38,10 @@ def display_societal_impact(year, include_indirect_impacts):
 
     display_df_year = display_df
     result_df_year = result_df
+
+    MOBILE_WIDTH_PX = 768
+    viewport_width = streamlit_js_eval(js_expressions="window.outerWidth", key = "WOW")
+
     # Display comparison table using the DataFrame
     st.subheader("Societal Impacts")
     st.write(

--- a/societal_impact.py
+++ b/societal_impact.py
@@ -2,6 +2,8 @@ import streamlit as st
 from policyengine_core.charts import *
 import pandas as pd
 import plotly.express as px
+import textwrap
+import math
 
 LABOUR = "#E4003B"
 CONSERVATIVES = "#0087DC"
@@ -168,6 +170,13 @@ def display_societal_impact(year, include_indirect_impacts, viewport_width):
             title = f"The {largest_impact_party} would increase {selected_metric_clean.lower()} the least in {year}"
     else:
         title = f"The {largest_impact_party} would decrease {selected_metric_clean.lower()} the most in {year}"
+
+
+    # Wrap title on mobile; this is hackish
+    ADJUSTMENT_FACTOR = 6
+    if viewport_width is not None and viewport_width < MOBILE_WIDTH_PX:
+        title_list = textwrap.wrap(title, viewport_width / ADJUSTMENT_FACTOR)
+        title = "<br>".join(title_list)
 
     metric_data = metric_data.apply(
         lambda x: (

--- a/societal_impact.py
+++ b/societal_impact.py
@@ -2,14 +2,13 @@ import streamlit as st
 from policyengine_core.charts import *
 import pandas as pd
 import plotly.express as px
-from streamlit_js_eval import streamlit_js_eval
 
 LABOUR = "#E4003B"
 CONSERVATIVES = "#0087DC"
 LIB_DEM = "#FAA61A"
 
 
-def display_societal_impact(year, include_indirect_impacts):
+def display_societal_impact(year, include_indirect_impacts, viewport_width):
     results_df = pd.read_csv("manifesto_impact.csv")
     results_df = results_df[
         results_df["Includes indirect impacts"] == include_indirect_impacts
@@ -42,7 +41,6 @@ def display_societal_impact(year, include_indirect_impacts):
     # Measure viewport width using JS; this will evaluate to None before paint,
     # then to the actual value, so must test if value is None before using
     MOBILE_WIDTH_PX = 768
-    viewport_width = streamlit_js_eval(js_expressions="window.outerWidth", key = "WOW")
 
     # Display comparison table using the DataFrame
     st.subheader("Societal Impacts")

--- a/societal_impact.py
+++ b/societal_impact.py
@@ -39,6 +39,8 @@ def display_societal_impact(year, include_indirect_impacts):
     display_df_year = display_df
     result_df_year = result_df
 
+    # Measure viewport width using JS; this will evaluate to None before paint,
+    # then to the actual value, so must test if value is None before using
     MOBILE_WIDTH_PX = 768
     viewport_width = streamlit_js_eval(js_expressions="window.outerWidth", key = "WOW")
 
@@ -52,6 +54,19 @@ def display_societal_impact(year, include_indirect_impacts):
     decile_data = decile_data[decile_data.Year == year][
         decile_data["Includes indirect impacts"] == include_indirect_impacts
     ]
+
+    if viewport_width is not None and viewport_width < MOBILE_WIDTH_PX:
+        plotly_x = 0
+        plotly_y = -0.2
+        plotly_yanchor = "top"
+        plotly_xanchor = "left"
+        plotly_orientation = "h"
+    else:
+        plotly_x = 1
+        plotly_y = 1
+        plotly_yanchor = "middle"
+        plotly_xanchor = "left"
+        plotly_orientation = "v"
 
     # Generate and display the decile impact chart
     fig_decile = (
@@ -75,6 +90,13 @@ def display_societal_impact(year, include_indirect_impacts):
         .update_layout(
             yaxis_tickformat="+,.0f",
             xaxis_tickvals=list(range(1, 11)),
+            legend={
+              "x": plotly_x,
+              "y": plotly_y,
+              "xanchor": plotly_xanchor,
+              "yanchor": plotly_yanchor,
+              "orientation": plotly_orientation
+            }
         )
     )
     # Update y-axis range

--- a/societal_impact.py
+++ b/societal_impact.py
@@ -56,17 +56,19 @@ def display_societal_impact(year, include_indirect_impacts, viewport_width):
     ]
 
     if viewport_width is not None and viewport_width < MOBILE_WIDTH_PX:
-        plotly_x = 0
-        plotly_y = -0.2
-        plotly_yanchor = "top"
-        plotly_xanchor = "left"
-        plotly_orientation = "h"
+        x = 0
+        y = -0.2
+        yanchor = "top"
+        xanchor = "left"
+        orientation = "h"
+        margin_r = 50
     else:
-        plotly_x = 1
-        plotly_y = 1
-        plotly_yanchor = "middle"
-        plotly_xanchor = "left"
-        plotly_orientation = "v"
+        x = 1
+        y = 1
+        yanchor = "middle"
+        xanchor = "left"
+        orientation = "v"
+        margin_r = 0
 
     # Generate and display the decile impact chart
     fig_decile = (
@@ -91,11 +93,14 @@ def display_societal_impact(year, include_indirect_impacts, viewport_width):
             yaxis_tickformat="+,.0f",
             xaxis_tickvals=list(range(1, 11)),
             legend={
-              "x": plotly_x,
-              "y": plotly_y,
-              "xanchor": plotly_xanchor,
-              "yanchor": plotly_yanchor,
-              "orientation": plotly_orientation
+              "x": x,
+              "y": y,
+              "xanchor": xanchor,
+              "yanchor": yanchor,
+              "orientation": orientation
+            },
+            margin={
+                "r": margin_r
             }
         )
     )
@@ -214,11 +219,14 @@ def display_societal_impact(year, include_indirect_impacts, viewport_width):
             else "+,.0%"
         ),
         legend={
-          "x": plotly_x,
-          "y": plotly_y,
-          "xanchor": plotly_xanchor,
-          "yanchor": plotly_yanchor,
-          "orientation": plotly_orientation
+          "x": x,
+          "y": y,
+          "xanchor": xanchor,
+          "yanchor": yanchor,
+          "orientation": orientation
+        },
+        margin={
+            "r": margin_r
         }
     )
     fig = format_fig(fig)

--- a/societal_impact.py
+++ b/societal_impact.py
@@ -204,6 +204,13 @@ def display_societal_impact(year, include_indirect_impacts, viewport_width):
             if selected_metric_clean in ["Cost", "Taxes", "Benefits"]
             else "+,.0%"
         ),
+        legend={
+          "x": plotly_x,
+          "y": plotly_y,
+          "xanchor": plotly_xanchor,
+          "yanchor": plotly_yanchor,
+          "orientation": plotly_orientation
+        }
     )
     fig = format_fig(fig)
     st.plotly_chart(fig, use_container_width=True)


### PR DESCRIPTION
Fixes #5.

PR adds a JS function to determine if user is on mobile breakpoint, and if they are:
* Moves chart legends below the chart
* Makes chart legends horizontal (where possible, above roughly 600px viewport width)
* Adds a slight margin to the right to fully display PolicyEngine logo
* Wraps chart text (though this will not work for about 0.5% of devices with a screen width lower than about 300px)

https://github.com/PolicyEngine/uk-2024-manifestos-comparison/assets/14987227/d185a048-ec9e-450e-8f64-d3339fc70c0c
