### PR TITLE
Add explicit fastapi[standard] to Modal image

### DIFF
--- a/api/modal_app.py
+++ b/api/modal_app.py
@@ -4,7 +4,7 @@ app = modal.App("uk-manifestos-comparison")
 
 image = (
     modal.Image.debian_slim(python_version="3.11")
-    .pip_install("policyengine-uk==2.22.0", "numpy<2")
+    .pip_install("fastapi[standard]", "policyengine-uk==2.22.0", "numpy<2")
 )
 
 


### PR DESCRIPTION
## Summary
- Modal no longer auto-installs FastAPI for `@modal.web_endpoint` functions — it must be declared explicitly in `pip_install`
- Without this, the Modal app fails to deploy with: "Web endpoint Functions require FastAPI to be installed in their Image"

## Test plan
- [x] Modal deploy succeeds: `https://policyengine--uk-manifestos-comparison-household.modal.run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)