### PR TITLE
Add multizone base path support

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,13 @@
 import type { NextConfig } from 'next';
 
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH !== undefined
+  ? process.env.NEXT_PUBLIC_BASE_PATH
+  : '/uk/2024-manifestos';
+
+
 const nextConfig: NextConfig = {
+  ...(basePath ? { basePath } : {}),
+  env: { NEXT_PUBLIC_BASE_PATH: basePath },
   transpilePackages: ['@mantine/core', '@mantine/hooks'],
   turbopack: {
     root: process.cwd(),

--- a/src/data/useData.ts
+++ b/src/data/useData.ts
@@ -6,7 +6,7 @@ export function useManifestoData() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    fetch("/data/manifesto_impact.json")
+    fetch(`${process.env.NEXT_PUBLIC_BASE_PATH || ""}/data/manifesto_impact.json`)
       .then((r) => r.json())
       .then((d: ManifestoImpact[]) => {
         setData(d);
@@ -22,7 +22,7 @@ export function useDecileData() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    fetch("/data/decile_impact.json")
+    fetch(`${process.env.NEXT_PUBLIC_BASE_PATH || ""}/data/decile_impact.json`)
       .then((r) => r.json())
       .then((d: DecileImpact[]) => {
         setData(d);


### PR DESCRIPTION
Adds a production base path for the PolicyEngine multizone mount and keeps local/root builds available with `NEXT_PUBLIC_BASE_PATH=` where the app uses Next.js.

Also prefixes root-relative public data/assets where needed so the zone loads correctly behind `policyengine.org` instead of only passing a framework build.

Verification:
- `git diff --check`