### PR TITLE
Add PolicyEngine header

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, Viewport } from 'next';
 import './globals.css';
+import PolicyEngineHeader from '@/components/PolicyEngineHeader';
 
 const SITE_URL = 'https://uk-2024-manifestos-comparison.vercel.app';
 const TITLE = 'UK 2024 manifestos comparison | PolicyEngine';
@@ -47,7 +48,10 @@ export default function RootLayout({
 }: Readonly<{ children: React.ReactNode }>) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <PolicyEngineHeader />
+        {children}
+      </body>
     </html>
   );
 }

--- a/src/components/PolicyEngineHeader.tsx
+++ b/src/components/PolicyEngineHeader.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { Header } from "@policyengine/ui-kit";
+
+const navItems = [
+  { label: "Research", href: "https://policyengine.org/uk/research" },
+  { label: "Model", href: "https://policyengine.org/uk/model" },
+  { label: "API", href: "https://policyengine.org/uk/api" },
+  {
+    label: "About",
+    href: "https://policyengine.org/uk/team",
+    children: [
+      { label: "Team", href: "https://policyengine.org/uk/team" },
+      { label: "Supporters", href: "https://policyengine.org/uk/supporters" },
+    ],
+  },
+  { label: "Donate", href: "https://policyengine.org/uk/donate" },
+];
+
+const countries = [
+  { id: "us", label: "United States" },
+  { id: "uk", label: "United Kingdom" },
+];
+
+export default function PolicyEngineHeader() {
+  return (
+    <Header
+      navItems={navItems}
+      countries={countries}
+      currentCountry="uk"
+      logoHref="https://policyengine.org/uk"
+      onCountryChange={(countryId) => {
+        window.location.href = `https://policyengine.org/${countryId}`;
+      }}
+    />
+  );
+}


### PR DESCRIPTION
## Summary\n- render the shared ui-kit PolicyEngine header above the manifesto comparison app\n- use UK nav/country defaults for the /uk/2024-manifestos zone\n\n## Tests\n- bun run lint\n- bun run test\n- bun run build